### PR TITLE
Fix app icon not applying icon theme and not allowing to add icon to dock in Solus/GNOME

### DIFF
--- a/io.freetubeapp.FreeTube.desktop
+++ b/io.freetubeapp.FreeTube.desktop
@@ -6,5 +6,6 @@ Exec=/app/bin/run.sh %u
 Icon=io.freetubeapp.FreeTube
 Type=Application
 StartupNotify=true
+StartupWMClass=FreeTube
 Categories=GNOME;GTK;Utility;
 MimeType=x-scheme-handler/freetube;


### PR DESCRIPTION
This is to fix App Icon not applying icon theme and not being able to add icon to dock in Solus and other GNOME based environments. I was able to fix this by adding this line to StartupWMClass=FreeTube to this file. After the latest flatpak update I had to reapply this line to the file. I was hoping to this fix can be pushed to the upstream. Thanks.
Read here for more info on the topic: https://discuss.getsol.us/d/3227-in-budgie-some-flatpaks-won-t-save-to-the-panel