### PR TITLE
Fix issue with builds only working with duplicate zip files

### DIFF
--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -45,7 +45,7 @@ modules:
         path: io.freetubeapp.FreeTube.metainfo.xml
     build-commands:
       # Bundle app
-      - install freetube-*.zip /app/freetube
+      - unzip freetube-*.zip -d /app/freetube
       # Install app wrapper
       - install run.sh /app/bin/
       # Install app icon and desktop file

--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -19,16 +19,16 @@ modules:
   - name: freetube
     buildsystem: simple
     sources:
-      - type: archive
+      - type: file
         only-arches:
           - x86_64
-        url: https://github.com/FreeTubeApp/FreeTube/releases/download/v0.9.3-beta/freetube_0.9.3_linux_portable_x64.zip
-        sha256: 7b57ed710ba4da2255607bb0edb3734b991e8f436b819fb957a69e6574fbc3c2
-      - type: archive
+        url: https://github.com/FreeTubeApp/FreeTube/releases/download/v0.9.3-beta/freetube-0.9.3-linux-portable-x64.zip
+        sha256: a678e55fa602f8e8dc01a965f889217c41cba59fd88b0d4bffe57212aa8c69ac
+      - type: file
         only-arches:
           - aarch64
-        url: https://github.com/FreeTubeApp/FreeTube/releases/download/v0.9.3-beta/freetube_0.9.3_linux_portable_arm64.zip
-        sha256: 67a9ad343bf5410ca89a6774070e69eb6801feed3b223949639496276dc90997
+        url: https://github.com/FreeTubeApp/FreeTube/releases/download/v0.9.3-beta/freetube-0.9.3-linux-portable-arm64.zip
+        sha256: 4eb88669e074387b668b5867c731733018015777013d18fcc47ec54112a0a805
       # Icon
       - type: file
         url: https://github.com/FreeTubeApp/FreeTube/raw/823a27899d32e064414ebba505936e86cada756e/_icons/iconColor.png
@@ -45,7 +45,7 @@ modules:
         path: io.freetubeapp.FreeTube.metainfo.xml
     build-commands:
       # Bundle app
-      - unzip freetube-*.zip -d /app/freetube
+      - install freetube-*.zip /app/freetube
       # Install app wrapper
       - install run.sh /app/bin/
       # Install app icon and desktop file


### PR DESCRIPTION
Testing a fix to the issue where the Flatpak build only works if it uses .zip files where the unzipped contents is another .zip file.