### PR TITLE
Confine config folder to sandbox

### DIFF
--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -16,6 +16,7 @@ finish-args:
   - --share=network
   - --env=TZ=UTC
   - --filesystem=xdg-download
+  - --persist=.config/FreeTube-Vue
   - --own-name=org.mpris.MediaPlayer2.freetube
 modules:
   - name: freetube


### PR DESCRIPTION
This pull request adds the flatpak --persist option to confine the config folder to the sandbox. See https://docs.flatpak.org/en/latest/sandbox-permissions.html for details