### PR TITLE
Remove broad `--socket=session-bus` access

### DIFF
--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -12,11 +12,15 @@ finish-args:
   - --share=ipc
   - --socket=x11
   - --socket=pulseaudio
-  - --socket=session-bus
   - --share=network
   - --env=TZ=UTC
   - --filesystem=xdg-download
+  - --own-name=org.mpris.MediaPlayer2.chromium.*
   - --own-name=org.mpris.MediaPlayer2.freetube
+  - --talk-name=org.freedesktop.PowerManagement
+  - --talk-name=org.freedesktop.ScreenSaver
+  - --talk-name=org.gnome.SessionManager
+  - --talk-name=org.gnome.SettingsDaemon
 modules:
   - name: freetube
     buildsystem: simple


### PR DESCRIPTION
Fixes https://github.com/flathub/io.freetubeapp.FreeTube/issues/64  but needs some testing.

- `org.gnome.SettingsDaemon` is for media keys which Freetube seems to support.

- `org.mpris.MediaPlayer2.chromium.*` and `org.mpris.MediaPlayer2.Player` is for persistent MPRIS notification.

- `org.freedesktop.PowerManagement`, `org.freedesktop.ScreenSaver` and `org.gnome.SessionManager` are the various interfaces used by [Chromium](https://source.chromium.org/chromium/chromium/src/+/main:services/device/wake_lock/power_save_blocker/power_save_blocker_linux.cc) (thus Electron's [powerSaveBlocker](https://www.electronjs.org/docs/latest/api/power-save-blocker) to prevent display sleep. Freetube uses this API to prevent display sleep while a video is playing.

Hi, @PrestonN if you have time please review. Thank you!
