### PR TITLE
Add org.freedesktop.Flatpak permission

### DIFF
--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -21,6 +21,7 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.gnome.SessionManager
   - --talk-name=org.gnome.SettingsDaemon
+  - --talk-name=org.freedesktop.Flatpak
 modules:
   - name: freetube
     buildsystem: simple


### PR DESCRIPTION
Fixes https://github.com/flathub/io.freetubeapp.FreeTube/issues/74

This isn't very ideal as it allows to run arbitrary commands from inside the sandbox. But there's no other solution I can think of since Freetube doesn't download the video, it only passes the link to the external player.

Tested with:

1. Flatpaked MPV https://github.com/FreeTubeApp/FreeTube/issues/1735#issuecomment-1141670904
2.  Host MPV https://github.com/FreeTubeApp/FreeTube/issues/1735#issuecomment-1029445701