### PR TITLE
Remove timezone workaround

### DIFF
--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -13,7 +13,6 @@ finish-args:
   - --socket=x11
   - --socket=pulseaudio
   - --share=network
-  - --env=TZ=UTC
   - --filesystem=xdg-download
   - --own-name=org.mpris.MediaPlayer2.chromium.*
   - --own-name=org.mpris.MediaPlayer2.freetube


### PR DESCRIPTION
Removing this will make FreeTube use the users timezone instead of defaulting to UTC.

closes https://github.com/FreeTubeApp/FreeTube/issues/1429

This workaround was added in https://github.com/flathub/io.freetubeapp.FreeTube/commit/279265af31ced8ccfe3e53a5b0e84a95c7011254 to prevent a crash.

I've tested and even using `--env=TZ=ETC/Unknown` does not cause any crashes.
running `Intl.DateTimeFormat().resolvedOptions().timeZone` returned `Undefined`
and new `Date().ToLocaleString()` returned `'16/09/2022'`