### PR TITLE
Update runtime to 22.08

### DIFF
--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -1,10 +1,10 @@
 app-id: io.freetubeapp.FreeTube
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 branch: stable
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '22.08'
 command: run.sh
 separate-locales: false
 finish-args:


### PR DESCRIPTION
There are some graphical corruption issues with FDO 21.08, Electron applications are primarily affected https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1460. Not sure if Freetube is specifically affected.

Also better to use newer runtime if it works :)