### PR TITLE
Enable wayland socket

### DIFF
--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -11,6 +11,7 @@ finish-args:
   - --device=dri
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --share=network
   - --env=TZ=UTC


### PR DESCRIPTION
Regarding https://github.com/flathub/io.freetubeapp.FreeTube/issues/67

This enables the wayland socket by default, so that people can try out Electron's experimental wayland support. The x11 socket is still needed as it defaults to that, `fallback-x11` won't work.

This will possibly show a warning/fail due to the [linter](https://github.com/flathub/flatpak-builder-lint/blob/ff408c87c1ebefe6276609eb536464fd181de5f9/flatpak_builder_lint/checks/finish_args.py#L37), so an exception needs to be requested in a [similar fashion](https://github.com/flathub/flatpak-builder-lint/blob/ff408c87c1ebefe6276609eb536464fd181de5f9/flatpak_builder_lint/staticfiles/exceptions.json#L1190) if necessary.

To test native wayland: 

```sh
flatpak run --nosocket=x11 io.freetubeapp.FreeTube --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations
```