### PR TITLE
Add Wayland Support

### DIFF
--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -44,7 +44,7 @@ modules:
         dest-filename: run.sh
         commands:
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
-          - exec zypak-wrapper /app/freetube/freetube --enable-features=UseOzonePlatform --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations "$@"
+          - exec zypak-wrapper /app/freetube/freetube --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations "$@"
       - type: file
         path: io.freetubeapp.FreeTube.desktop
       - type: file

--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -10,9 +10,8 @@ separate-locales: false
 finish-args:
   - --device=dri
   - --share=ipc
-  - --socket=x11
-  - --socket=wayland
   - --socket=fallback-x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --share=network
   - --filesystem=xdg-download
@@ -45,12 +44,7 @@ modules:
         dest-filename: run.sh
         commands:
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
-          - if [ -e $XDG_RUNTIME_DIR/${WAYLAND_DISPLAY:=wayland-0} ]; then,
-          - wayland_check="--enable-features=UseOzonePlatform --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations",
-          - else,
-          - wayland_check="",
-          - fi,
-          - exec zypak-wrapper /app/freetube/freetube $wayland_check "$@"
+          - exec zypak-wrapper /app/freetube/freetube --enable-features=UseOzonePlatform --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations "$@"
       - type: file
         path: io.freetubeapp.FreeTube.desktop
       - type: file

--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -11,6 +11,8 @@ finish-args:
   - --device=dri
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --share=network
   - --filesystem=xdg-download
@@ -43,7 +45,12 @@ modules:
         dest-filename: run.sh
         commands:
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
-          - exec zypak-wrapper /app/freetube/freetube "$@"
+          - if [ -e $XDG_RUNTIME_DIR/${WAYLAND_DISPLAY:=wayland-0} ]; then,
+          - wayland_check="--enable-features=UseOzonePlatform --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations",
+          - else,
+          - wayland_check="",
+          - fi,
+          - exec zypak-wrapper /app/freetube/freetube $wayland_check "$@"
       - type: file
         path: io.freetubeapp.FreeTube.desktop
       - type: file

--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -10,7 +10,7 @@ separate-locales: false
 finish-args:
   - --device=dri
   - --share=ipc
-  - --socket=fallback-x11
+  - --socket=x11
   - --socket=wayland
   - --socket=pulseaudio
   - --share=network
@@ -40,11 +40,8 @@ modules:
         url: https://raw.githubusercontent.com/FreeTubeApp/FreeTube/master/_icons/icon.svg
         sha256: a4ca2007a3e21d776095ab54c9de0811a53cc3adb9a0219629baa1198ca4ffb4
       # Wrapper to launch the app
-      - type: script
-        dest-filename: run.sh
-        commands:
-          - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
-          - exec zypak-wrapper /app/freetube/freetube --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations "$@"
+      - type: file
+        path: run.sh
       - type: file
         path: io.freetubeapp.FreeTube.desktop
       - type: file

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 
-FLAGS=''
+EXTRA_FLAGS=()
 
 # Display Socket
-if [ "$XDG_SESSION_TYPE" = "wayland" ] && [ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]; then
-    FLAGS="$FLAGS --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations"
+if [ "${XDG_SESSION_TYPE}" = "wayland" ] && [ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]; then
+    EXTRA_FLAGS+=(
+        "--enable-features=WaylandWindowDecorations"
+        "--ozone-platform-hint=auto"
+    )
 fi
 
-env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-io.freetubeapp.FreeTube}" zypak-wrapper /app/freetube/freetube "$FLAGS" "$@"
+export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}" 
+exec zypak-wrapper /app/freetube/freetube "${EXTRA_FLAGS[@]}" "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+FLAGS=''
+
+# Display Socket
+if [ "$XDG_SESSION_TYPE" = "wayland" ] && [ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]; then
+    FLAGS="$FLAGS --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations"
+fi
+
+env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-io.freetubeapp.FreeTube}" zypak-wrapper /app/freetube/freetube "$FLAGS" "$@"


### PR DESCRIPTION
After adding the correct flags for Electron, and using the right sockets, this PR will add native wayland support and fixes the stuttering that was happening under xwayland ( [ issue #85 ](https://github.com/flathub/io.freetubeapp.FreeTube/issues/85)). 

This will also remove the "Legacy windowing system (X11)"  alert on Flathub.

Tested under Wayland and X11
