### PR TITLE
Drop the wayland socket and make native wayland opt-in

### DIFF
--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -11,7 +11,6 @@ finish-args:
   - --device=dri
   - --share=ipc
   - --socket=x11
-  - --socket=wayland
   - --socket=pulseaudio
   - --share=network
   - --filesystem=xdg-download


### PR DESCRIPTION
See https://docs.flatpak.org/en/latest/electron.html#sandbox-permissions

Electron still considers native wayland to be unstable and doesn't enable it by default in Wayland desktop environments. An app should follow upstream Electron recommendation to avoid bug reports.

Users who want to enable native wayland can run with `flatpak run --socket=wayland io.freetubeapp.FreeTube` or add it as a permanent override with
`flatpak override --user --socket=wayland io.freetubeapp.FreeTube`