### PR TITLE
add default Wayland support

### DIFF
--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -10,7 +10,8 @@ separate-locales: false
 finish-args:
   - --device=dri
   - --share=ipc
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --share=network
   - --filesystem=xdg-download
@@ -20,6 +21,7 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.gnome.SessionManager
   - --talk-name=org.gnome.SettingsDaemon
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
 modules:
   - name: freetube
     buildsystem: simple


### PR DESCRIPTION
this will make Freetube default to Wayland when using Wayland. On X11 it will use X11 as fallback. Disabling the Wayland permission will make it use XWayland also on Wayland sessions.

#104 

I will use it like that. the only issue to my knowledge, PiP mode, also works fine. It may need a Window rule to keep the window in the foreground.