### PR TITLE
Fix wayland socket detection.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 EXTRA_FLAGS=()
 
 # Display Socket
-if [ "${XDG_SESSION_TYPE}" = "wayland" ] && [ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]; then
+if [ "${XDG_SESSION_TYPE}" = "wayland" ] && [ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" -o -e "${WAYLAND_DISPLAY}" ]; then
     EXTRA_FLAGS+=(
         "--enable-features=WaylandWindowDecorations"
         "--ozone-platform-hint=auto"


### PR DESCRIPTION
While the existing logic is sufficient in some cases, it does not work on an arch linux install as $WAYLAND_DISPLAY is a full path rather than just the socket's filename.