### PR TITLE
Fix wayland titlebar icon.

### DIFF
--- a/io.freetubeapp.FreeTube.yml
+++ b/io.freetubeapp.FreeTube.yml
@@ -54,3 +54,4 @@ modules:
       - install -Dm644 icon.svg /app/share/icons/hicolor/scalable/apps/io.freetubeapp.FreeTube.svg
       - install -Dm644 io.freetubeapp.FreeTube.desktop -t /app/share/applications/
       - install -Dm644 io.freetubeapp.FreeTube.metainfo.xml -t /app/share/metainfo/
+      - patch-desktop-filename "${FLATPAK_DEST}"/freetube/resources/app.asar


### PR DESCRIPTION
The source archive version's app_id is set to FreeTube instead of matching the flatpak's .desktop file with io.freetubeapp.FreeTube.

References:
  - https://docs.flatpak.org/en/latest/electron.html#using-correct-desktop-file-name
  - https://github.com/flathub/com.discordapp.Discord/blob/85a9173948c258de390af77fac7476776427dc0f/com.discordapp.Discord.json#L109
  
Before: 
![Screenshot_20241114_100759](https://github.com/user-attachments/assets/1437c534-cc6e-4323-b631-181a9a20969e)

After:
![Screenshot_20241114_100732](https://github.com/user-attachments/assets/b3477b50-b7b6-4125-b77e-7918b1b32515)
