### PR TITLE
[Draft] Enable Wayland text-input-v3

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,8 @@ if [ "${XDG_SESSION_TYPE}" = "wayland" ] && [ -e "${XDG_RUNTIME_DIR}/${WAYLAND_D
     EXTRA_FLAGS+=(
         "--enable-features=WaylandWindowDecorations"
         "--ozone-platform-hint=auto"
+        "--enable-wayland-ime"
+        "--wayland-text-input-version=3"
     )
 fi
 


### PR DESCRIPTION
Aimed at the next release, where the electron version is bumped into 33. This change will enable input method using `text-input-v3`, which is required on popular desktop environment like gnome.

See this issue for detail: https://github.com/electron/electron/issues/33662

**This is currently a draft PR, testing is still required**