### PR TITLE
Update metainfo to show support for Linux mobile

### DIFF
--- a/io.freetubeapp.FreeTube.metainfo.xml
+++ b/io.freetubeapp.FreeTube.metainfo.xml
@@ -48,6 +48,15 @@
     <content_attribute id="social-audio">moderate</content_attribute>
     <content_attribute id="social-contacts">intense</content_attribute>
   </content_rating>
+  <!-- Desktop AND mobile supported -->
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>touch</control>
+  </supports>
+  <requires>
+    <display_length compare="ge">360</display_length>
+  </requires>
   <releases>
     <release version="0.22.1 Beta" date="2024-12-12">
       <url>https://github.com/FreeTubeApp/FreeTube/releases/tag/v0.22.1-beta</url>


### PR DESCRIPTION
closes https://github.com/flathub/io.freetubeapp.FreeTube/issues/125

Based on info provided here:
https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#desktop-and-mobile-apps
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-relations-control