### PR TITLE
Update appstream metadata

### DIFF
--- a/io.freetubeapp.FreeTube.desktop
+++ b/io.freetubeapp.FreeTube.desktop
@@ -7,5 +7,5 @@ Icon=io.freetubeapp.FreeTube
 Type=Application
 StartupNotify=true
 StartupWMClass=FreeTube
-Categories=AudioVideo;Network;Utility;
+Categories=AudioVideo;Video;Player;Feed;Network;
 MimeType=x-scheme-handler/freetube;

--- a/io.freetubeapp.FreeTube.desktop
+++ b/io.freetubeapp.FreeTube.desktop
@@ -8,4 +8,5 @@ Type=Application
 StartupNotify=true
 StartupWMClass=FreeTube
 Categories=AudioVideo;Video;Player;Feed;Network;
+Keywords=youtube;video;yt;invidious;sponsorblock;
 MimeType=x-scheme-handler/freetube;

--- a/io.freetubeapp.FreeTube.desktop
+++ b/io.freetubeapp.FreeTube.desktop
@@ -7,5 +7,5 @@ Icon=io.freetubeapp.FreeTube
 Type=Application
 StartupNotify=true
 StartupWMClass=FreeTube
-Categories=GNOME;GTK;AudioVideo;Network;Utility;
+Categories=AudioVideo;Network;Utility;
 MimeType=x-scheme-handler/freetube;

--- a/io.freetubeapp.FreeTube.metainfo.xml
+++ b/io.freetubeapp.FreeTube.metainfo.xml
@@ -4,7 +4,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>AGPL-3.0+</project_license>
   <name>FreeTube</name>
-  <summary>A private way to watch YouTube</summary>
+  <summary>Watch YouTube privately</summary>
   <developer id="io.freetubeapp">
     <name>FreeTube Team</name>
   </developer>
@@ -20,8 +20,8 @@
   <launchable type="desktop-id">io.freetubeapp.FreeTube.desktop</launchable>
   
   <branding>
-    <color type="primary" scheme_preference="light">#29abe1</color>
-    <color type="primary" scheme_preference="dark">#ff3333</color>
+    <color type="primary" scheme_preference="light">#f06a73</color>
+    <color type="primary" scheme_preference="dark">#8b1e2d</color>
   </branding>
 
   <content_rating type="oars-1.1" />

--- a/io.freetubeapp.FreeTube.metainfo.xml
+++ b/io.freetubeapp.FreeTube.metainfo.xml
@@ -19,14 +19,8 @@
   </description>
   <launchable type="desktop-id">io.freetubeapp.FreeTube.desktop</launchable>
   
-  <categories>
-    <category>AudioVideo</category>
-    <category>Video</category>
-    <category>Player</category>
-  </categories>
-
   <branding>
-    <color type="primary" scheme_preference="light">#ff3333</color>
+    <color type="primary" scheme_preference="light">#29abe1</color>
     <color type="primary" scheme_preference="dark">#ff3333</color>
   </branding>
 

--- a/io.freetubeapp.FreeTube.metainfo.xml
+++ b/io.freetubeapp.FreeTube.metainfo.xml
@@ -2,8 +2,12 @@
 <component type="desktop-application">
   <id>io.freetubeapp.FreeTube</id>
   <metadata_license>CC0-1.0</metadata_license>
+  <project_license>AGPL-3.0+</project_license>
   <name>FreeTube</name>
-  <summary>An Open Source YouTube app for privacy</summary>
+  <summary>A private way to watch YouTube</summary>
+  <developer id="io.freetubeapp">
+    <name>FreeTube Team</name>
+  </developer>
   <description>
     <p>FreeTube is an open source desktop YouTube player built with privacy in
     mind. Use YouTube without advertisements and prevent Google from tracking
@@ -14,11 +18,20 @@
     addressed.</p>
   </description>
   <launchable type="desktop-id">io.freetubeapp.FreeTube.desktop</launchable>
+  
   <categories>
     <category>AudioVideo</category>
     <category>Video</category>
     <category>Player</category>
   </categories>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#ff3333</color>
+    <color type="primary" scheme_preference="dark">#ff3333</color>
+  </branding>
+
+  <content_rating type="oars-1.1" />
+
   <url type="homepage">https://freetubeapp.io/</url>
   <url type="bugtracker">https://github.com/FreeTubeApp/FreeTube/issues</url>
   <url type="help">https://docs.freetubeapp.io/</url>
@@ -26,10 +39,7 @@
   <url type="vcs-browser">https://github.com/FreeTubeApp/FreeTube</url>
   <url type="translate">https://hosted.weblate.org/engage/free-tube/</url>
   <url type="contact">https://freetubeapp.io/#contact</url>
-  <project_license>AGPL-3.0+</project_license>
-  <developer id="io.freetubeapp">
-    <name>FreeTube Team</name>
-  </developer>
+
   <screenshots>
     <screenshot type="default">
       <caption>The main FreeTube window</caption>
@@ -44,12 +54,7 @@
       <image type="source" width="1920" height="1040">https://raw.githubusercontent.com/FreeTubeApp/FreeTubeApp.io/master/src/images/FreeTube3.png</image>
     </screenshot>
   </screenshots>
-  <content_rating type="oars-1.1" />
-  <branding>
-    <color type="primary" scheme_preference="light">#ff3333</color>
-    <color type="primary" scheme_preference="dark">#ff3333</color>
-  </branding>
-  <!-- Desktop AND mobile supported -->
+
   <supports>
     <control>keyboard</control>
     <control>pointing</control>
@@ -61,6 +66,7 @@
   <requires>
     <display_length compare="ge">360</display_length>
   </requires>
+
   <releases>
     <release version="v0.25.2-beta" date="2026-08-11">
       <url type="details">https://github.com/FreeTubeApp/FreeTube/releases/tag/v0.25.2-beta</url>

--- a/io.freetubeapp.FreeTube.metainfo.xml
+++ b/io.freetubeapp.FreeTube.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id type="desktop-application">io.freetubeapp.FreeTube</id>
+  <id>io.freetubeapp.FreeTube</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>FreeTube</name>
   <summary>An Open Source YouTube app for privacy</summary>
@@ -17,6 +17,7 @@
   <categories>
     <category>AudioVideo</category>
     <category>Video</category>
+    <category>Player</category>
   </categories>
   <url type="homepage">https://freetubeapp.io/</url>
   <url type="bugtracker">https://github.com/FreeTubeApp/FreeTube/issues</url>
@@ -24,8 +25,11 @@
   <url type="contribute">https://docs.freetubeapp.io/development/getting-started</url>
   <url type="vcs-browser">https://github.com/FreeTubeApp/FreeTube</url>
   <url type="translate">https://hosted.weblate.org/engage/free-tube/</url>
+  <url type="contact">https://freetubeapp.io/#contact</url>
   <project_license>AGPL-3.0+</project_license>
-  <developer_name>FreeTube Team</developer_name>
+  <developer id="io.freetubeapp">
+    <name>FreeTube Team</name>
+  </developer>
   <screenshots>
     <screenshot type="default">
       <caption>The main FreeTube window</caption>
@@ -40,17 +44,20 @@
       <image type="source" width="1920" height="1040">https://raw.githubusercontent.com/FreeTubeApp/FreeTubeApp.io/master/src/images/FreeTube3.png</image>
     </screenshot>
   </screenshots>
-  <content_rating type="oars-1.0">
-    <content_attribute id="social-chat">moderate</content_attribute>
-    <content_attribute id="social-audio">moderate</content_attribute>
-    <content_attribute id="social-contacts">intense</content_attribute>
-  </content_rating>
+  <content_rating type="oars-1.1" />
+  <branding>
+    <color type="primary" scheme_preference="light">#ff3333</color>
+    <color type="primary" scheme_preference="dark">#ff3333</color>
+  </branding>
   <!-- Desktop AND mobile supported -->
   <supports>
     <control>keyboard</control>
     <control>pointing</control>
     <control>touch</control>
   </supports>
+  <recommends>
+    <internet>always</internet>
+  </recommends>
   <requires>
     <display_length compare="ge">360</display_length>
   </requires>


### PR DESCRIPTION
Fixed some warnings shown when running `appstreamcli validate ./io.freetubeapp.FreeTube.metainfo.xml`

Warnings found:
```
I: io.freetubeapp.FreeTube:3: id-tag-has-type io.freetubeapp.FreeTube
   The <id/> tag still contains a `type` property, probably from an old conversion to the recent
   metainfo format.

I: io.freetubeapp.FreeTube:28: developer-name-tag-deprecated
   The toplevel `developer_name` element is deprecated. Please use the `name` element in a
   `developer` block instead.

I: io.freetubeapp.FreeTube:~: developer-info-missing
   This component contains no `developer` element with information about its author.

```


I also added branding and a link to our contact page :smile: 

Here's what our branding would look like:
<img width="1286" height="851" alt="FreeTube flathub branding preview showing a red background" src="https://github.com/user-attachments/assets/7be7f60e-b364-40f1-9c58-988ec670ad1c" />

